### PR TITLE
Fixes issue with files name containing colon `:`

### DIFF
--- a/android/src/main/kotlin/io/cloudacy/pdf_image_renderer/PdfImageRendererPlugin.kt
+++ b/android/src/main/kotlin/io/cloudacy/pdf_image_renderer/PdfImageRendererPlugin.kt
@@ -377,7 +377,9 @@ class PdfImageRendererPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
     private fun getURI(uri: String): Uri {
         val parsed: Uri = Uri.parse(uri)
         val parsedScheme: String? = parsed.scheme
-        return if ((parsedScheme == null) || parsedScheme.isEmpty()) {
+        return if ((parsedScheme == null) || parsedScheme.isEmpty() || "${uri[0]}" == "/") {
+            // Using "${uri[0]}" == "/" in condition above because if uri is an absolute file path without any scheme starting with "/"
+            // and if its filename contains ":" then the parsed scheme will be wrong.
             Uri.fromFile(File(uri))
         } else parsed
     }


### PR DESCRIPTION
If the file path passed is an absolute file path and if its name contains colon `:` then the URI parsed will be wrong as the scheme parsed will be not unusable.

More detail:-
Example path with issue: `/data/user/0/com.example.appname/cache/2022-11-05 20:53:17.783069.png`.
Now, for the example the `parsedScheme` in `getURI` will be `/data/user/0/com.example.appname/cache/2022-11-05 20` as a scheme is anything before colon. Due to this `getURI` will return us the same string passed which will be unusable further down the code. 

So, what we do is check if the string passed to `getURI` starts with `/` or not, if it starts with `/` then most probably it is an absolute file path.

Let me know if you have any questions about this change.
